### PR TITLE
readme, travis, etc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,39 @@
+language: rust
+rust:
+  - stable
+  - beta
+  - nightly
+
+os:
+  - linux
+  - osx
+
+branches:
+  except:
+    - test
+
+notifications:
+  irc:
+    channels: "chat.freenode.net#zetox"
+    template:
+      - "%{repository}#%{build_number} (%{branch} - %{commit} : %{author}): %{message} || Change view: %{compare_url}"
+    on_success: change
+    skip_join: true
+
+matrix:
+  allow_failures:
+  - rust: beta
+  - rust: nightly
+  - os: osx
+
+sudo: required
+
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then bash ./scripts/verify-commit-messages.sh "$TRAVIS_COMMIT_RANGE" ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then bash ./scripts/bootstrap-ubuntu-14-04.sh; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then bash ./scripts/bootstrap-osx.sh; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PKG_CONFIG_PATH=$HOME/installed_libsodium/lib/pkgconfig:$PKG_CONFIG_PATH ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export LD_LIBRARY_PATH=$HOME/installed_libsodium/lib:$LD_LIBRARY_PATH ; fi
+
+script:
+ - make

--- a/README.md
+++ b/README.md
@@ -1,5 +1,32 @@
-tox-capi
+tox-capi [![Build Status](https://travis-ci.org/quininer/tox-capi.svg?branch=master)](https://travis-ci.org/quininer/tox-capi)
 --------
 
-[tox](https://github.com/zetok/tox) C API,
-goal is compatible [toxcore](https://github.com/irungentoo/toxcore).
+C API for [zetox], a [toxcore] implementation in Rust.
+Aims to be compatible with C toxcore.
+
+Powered by [rusty-cheddar].
+
+
+## Dependencies
+| **Name** | **Version** |
+|----------|-------------|
+| libsodium | >=1.0.0 |
+
+
+## Building
+Fairly simple. You'll need [Rust] and [libsodium].
+
+When you'll have deps, build debug version with
+```bash
+make
+```
+
+## License
+
+Licensed under GPLv3+. For details, see [LICENSE](/LICENSE).
+
+[libsodium]: https://github.com/jedisct1/libsodium
+[Rust]: https://www.rust-lang.org/
+[rusty-cheddar]: https://github.com/Sean1708/rusty-cheddar
+[toxcore]: https://github.com/irungentoo/toxcore
+[zetox]: https://github.com/zetok/tox

--- a/scripts/bootstrap-osx.sh
+++ b/scripts/bootstrap-osx.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# used in travis to:
+#  - build libsodium
+
+git clone https://github.com/jedisct1/libsodium.git
+cd libsodium
+git checkout tags/1.0.8
+./autogen.sh
+./configure --prefix=$HOME/installed_libsodium && \
+    make -j$(nproc) && \
+    make install
+cd ..

--- a/scripts/bootstrap-ubuntu-14-04.sh
+++ b/scripts/bootstrap-ubuntu-14-04.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# used in travis to:
+#  - pull in dependencies for building libsodium
+#  - build required libsodium
+
+sudo apt-get update -qq
+sudo apt-get install -y build-essential libtool autotools-dev automake checkinstall check git yasm pkg-config
+git clone https://github.com/jedisct1/libsodium.git
+cd libsodium
+git checkout tags/1.0.8
+./autogen.sh
+./configure && make -j$(nproc)
+sudo checkinstall --install --pkgname libsodium --pkgversion 1.0.8 --nodoc -y
+sudo ldconfig
+cd ..

--- a/scripts/verify-commit-messages.sh
+++ b/scripts/verify-commit-messages.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+#    Copyright © 2016 Zetok Zalbavar <zetok@openmailbox.org>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Script for verifying conformance to commit message format of commits in commit
+# range supplied.
+#
+# Scrpt fails (non-zero exit status) if commit messages don't conform.
+
+# usage:
+#   ./$script $commit_range
+#
+# $commit_range – in format `abdce..12345`
+
+ARG="$1"
+
+echo "" # ← formatting
+
+# Conform, /OR ELSE/.
+if git log --format=format:'%s' "$ARG" | \
+    grep -v -E '^((feat|fix|docs|style|refactor|perf|revert|test|chore)(\(.+\))?:.{1,68})|(Merge pull request #[[:digit:]]{1,10})$'
+then
+    echo ""
+    echo "Above ↑ commits don't conform to commit message format:"
+    echo "https://github.com/zetok/tox/blob/master/CONTRIBUTING.md#commit-message-format"
+    echo ""
+    echo "Pls fix."
+    echo ""
+    echo "If you're not sure how to rewrite history, here's a helpful tutorial:"
+    echo "https://www.atlassian.com/git/tutorials/rewriting-history/git-commit--amend/"
+    echo ""
+    echo -n "If you're still not sure what to do, feel free to pop on IRC, or "
+    echo "ask in PR comments for help :)"
+    # fail the build
+    exit 1
+fi


### PR DESCRIPTION
- Travis CI integration
  - will send notification to #zetox @ freenode whenever build fails / is fixed
  - will check conformance of commits to commit message format used by zetox
  - will build on osx & Linux & all Rust channels
    - required to have successful build only on Linux with stable Rust, I can add osx + stable Rust to required builds
  - will build every branch except for the one named `test`

If you're fine with `#zetox` channel on freenode, I'd add it to README.md..?

If some of those changes aren't good, I'll amend stuff.

Travis support will require enabling this repo: https://travis-ci.org/quininer/tox-capi
