### PR TITLE
docs(README.md): point to the correct place of travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-tox-capi [![Build Status](https://travis-ci.org/quininer/tox-capi.svg?branch=master)](https://travis-ci.org/quininer/tox-capi)
+tox-capi [![Build Status](https://travis-ci.org/ze-tox/tox-capi.svg?branch=master)](https://travis-ci.org/ze-tox/tox-capi)
 --------
 
 C API for [zetox], a [toxcore] implementation in Rust.


### PR DESCRIPTION
Forgot to change that when repo was moved.
